### PR TITLE
bugfix: do not use json.loads() for response.json

### DIFF
--- a/check_smseagle
+++ b/check_smseagle
@@ -150,7 +150,7 @@ def get_strength(response):
     """
     Parse response and returns signal_strength of given modem
     """
-    data = json.loads(response.json())
+    data = response.json()
     return data["signal_strength"]
 
 


### PR DESCRIPTION
- response.json() is already a json object, not a string
- json.loads() causes error trying to load json object